### PR TITLE
Exclude .sops.yaml from cluster validation

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -45,7 +45,7 @@ done
 kubeconform_config="-strict -ignore-missing-schemas -schema-location default -schema-location /tmp/flux-crd-schemas -verbose"
 
 echo "INFO - Validating clusters"
-find . -maxdepth 2 -type f -name '.sops.yaml' -prune -o -name '*.yaml' -print0 | while IFS= read -r -d $'\0' file;
+find ./clusters -maxdepth 2 -type f -name '.sops.yaml' -prune -o -name '*.yaml' -print0 | while IFS= read -r -d $'\0' file;
   do
     kubeconform $kubeconform_config ${file}
     if [[ ${PIPESTATUS[0]} != 0 ]]; then

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -45,7 +45,7 @@ done
 kubeconform_config="-strict -ignore-missing-schemas -schema-location default -schema-location /tmp/flux-crd-schemas -verbose"
 
 echo "INFO - Validating clusters"
-find ./clusters -maxdepth 2 -type f -name '*.yaml' -print0 | while IFS= read -r -d $'\0' file;
+find . -maxdepth 2 -type f -name '.sops.yaml' -prune -o -name '*.yaml' -print0 | while IFS= read -r -d $'\0' file;
   do
     kubeconform $kubeconform_config ${file}
     if [[ ${PIPESTATUS[0]} != 0 ]]; then


### PR DESCRIPTION
Flux expects the `.sops.yaml` file to be located here for secret decryption purposes. However, since it isn't a valid kubernetes resource, it fails the check.

This PR excludes the .sops.yaml from being validated if it exists.